### PR TITLE
Fix exists with condition

### DIFF
--- a/src/ripe_rainbow/domain/base/assertions.py
+++ b/src/ripe_rainbow/domain/base/assertions.py
@@ -73,25 +73,9 @@ class AssertionsPart(parts.Part):
         return elements
 
     def exists(self, selector, condition = None):
-        has_condition = True if condition else False
-        if not condition: condition = lambda e: True
+        matching = self.exists_multiple(selector, condition = condition)
 
-        try:
-            element = self.driver.find_element_by_css_selector(selector)
-        except NoSuchElementException:
-            self.logger.debug("Could not find element with '%s'" % selector)
-            return None
-
-        if not condition(element):
-            self.logger.debug("Found element with '%s' but doesn't match condition" % selector)
-            return None
-
-        if has_condition:
-            self.logger.debug("Found element with '%s' that matches the condition" % selector)
-        else:
-            self.logger.debug("Found element with '%s'" % selector)
-
-        return element
+        return matching[0] if len(matching) > 0 else None
 
     def is_visible(self, selector):
         element = self.exists(selector)

--- a/src/ripe_rainbow/domain/base/interactions.py
+++ b/src/ripe_rainbow/domain/base/interactions.py
@@ -26,8 +26,8 @@ class InteractionsPart(parts.Part):
             self.logger.debug("Element is not \"clickable\" because: %s" % exception)
             return None
 
-    def click_when_possible(self, selector):
-        element = self.waits.element(selector)
+    def click_when_possible(self, selector, condition = None):
+        element = self.waits.element(selector, condition = condition)
         return self.waits.until(
             lambda d: self.try_click(element),
             "Element '%s' found but never became clickable" % selector


### PR DESCRIPTION
Exists wouldn't work properly with conditions, since the `find` would return the first element it encountered even if it failed the condition. This is bad because there might be other elements that would match both the selector and the condition.