### PR TITLE
Add console errors checking

### DIFF
--- a/src/ripe_rainbow/errors.py
+++ b/src/ripe_rainbow/errors.py
@@ -4,10 +4,22 @@
 import appier
 
 class SkipError(appier.AppierException):
-    
+
     def __init__(self, *args, **kwargs):
         appier.AppierException.__init__(self, *args)
         self.reason = kwargs.get("reason", None)
 
 class TimeoutError(appier.AppierException):
     pass
+
+class ConsoleErrorsError(appier.AppierException):
+    def __init__(self, *args, **kwargs):
+        self.errors = kwargs.get("errors", None)
+        separator = "\n\t"
+        errors_s = separator.join("'%s'" % error["message"] for error in self.errors)
+
+        appier.AppierException.__init__(
+            self,
+            *args,
+            message = "Some errors were found in the console:%s%s" % (separator, errors_s)
+        )

--- a/src/ripe_rainbow/interactive/test_cases.py
+++ b/src/ripe_rainbow/interactive/test_cases.py
@@ -22,6 +22,7 @@ class InteractiveTestCase(test_cases.TestCase):
 
     def after(self):
         if self.driver:
+            self.driver.check_errors()
             self.driver.stop()
             self.driver = None
         test_cases.TestCase.after(self)


### PR DESCRIPTION
Have the driver be able to throw `ConsoleErrorsError` when there are errors in the console during a test.

The logs are cleared every time they're read, so a failing test shouldn't make others to fail.