### PR TITLE
Fixes the scrolling sleep after click

### DIFF
--- a/src/ripe_rainbow/domain/base/interactions.py
+++ b/src/ripe_rainbow/domain/base/interactions.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+import time
+
 from .. import parts
 
 class InteractionsPart(parts.Part):
@@ -79,7 +81,7 @@ class InteractionsPart(parts.Part):
         # waits for the element to be available at the DOM and then
         # optionally runs the scroll operation to the element
         element = self.waits.element(selector, condition = condition)
-        if scroll: self.driver.safe(self.driver.scroll_to, element)
+        if scroll: self.driver.safe(self.driver.scroll_to, element, sleep = scroll_sleep)
 
         # waits for the proper visibility of the element, should be ensured
         # by having the element "inside" the current browser viewport
@@ -88,14 +90,6 @@ class InteractionsPart(parts.Part):
         # waits until the try click operation is possible meaning that a
         # proper click has been "done" by the driver
         return self.waits.until(
-            lambda d: self._try_click(element, scroll = scroll, scroll_sleep = scroll_sleep),
+            lambda d: self.driver.safe(self.driver.click, element),
             "Element '%s' found but never became clickable" % selector
-        )
-
-    def _try_click(self, element, scroll = True, scroll_sleep = None):
-        return self.driver.safe(
-            self.driver.click,
-            element,
-            scroll = scroll,
-            scroll_sleep = scroll_sleep
         )

--- a/src/ripe_rainbow/domain/base/interactions.py
+++ b/src/ripe_rainbow/domain/base/interactions.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import time
-
 from .. import parts
 
 class InteractionsPart(parts.Part):

--- a/src/ripe_rainbow/domain/logic/ripe_retail.py
+++ b/src/ripe_rainbow/domain/logic/ripe_retail.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+import time
+
 import appier
 
 from .. import parts
@@ -112,6 +114,11 @@ class RipeRetailPart(parts.Part):
             ".pickers .button-part > p:not(.no-part)",
             condition = lambda e: e.text == part.upper()
         )
+
+        # the color transition must finish before we can keep going,
+        # otherwise scrolling to the correct color won't work
+        time.sleep(1)
+
         self.interactions.click_when_possible(
             ".pickers .button-color[data-material='%s'][data-color='%s']" % (material, color),
             scroll_sleep = color_scroll_sleep

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -46,7 +46,7 @@ class InteractiveDriver(object):
     def press_enter(self, element):
         return self.press_key(element, "enter")
 
-    def click(self, element, scroll = True, scroll_sleep = None):
+    def click(self, element, scroll = True):
         raise appier.NotImplementedError()
 
     def scroll_to(self, element, sleep = None):
@@ -125,7 +125,7 @@ class SeleniumDriver(InteractiveDriver):
         element.send_keys(text)
         return element
 
-    def click(self, element, scroll = True, scroll_sleep = None):
+    def click(self, element, scroll = True):
         from selenium.webdriver.common.action_chains import ActionChains
         from selenium.common.exceptions import ElementClickInterceptedException, ElementNotVisibleException, WebDriverException
 
@@ -133,7 +133,7 @@ class SeleniumDriver(InteractiveDriver):
             if scroll:
                 # runs the scroll operation with the request amount of sleep time
                 # for the scroll operation (important to guarantee visibility)
-                self.scroll_to(element, sleep = scroll_sleep)
+                self.scroll_to(element)
 
                 # a new object for the chain of actions of the current instance and
                 # then moves to the target element and runs the click operation

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -131,8 +131,7 @@ class SeleniumDriver(InteractiveDriver):
 
         try:
             if scroll:
-                # runs the scroll operation with the request amount of sleep time
-                # for the scroll operation (important to guarantee visibility)
+                # runs the scroll operation (important to guarantee visibility)
                 self.scroll_to(element)
 
                 # a new object for the chain of actions of the current instance and

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -131,9 +131,6 @@ class SeleniumDriver(InteractiveDriver):
 
         try:
             if scroll:
-                # runs the scroll operation (important to guarantee visibility)
-                self.scroll_to(element)
-
                 # a new object for the chain of actions of the current instance and
                 # then moves to the target element and runs the click operation
                 actions = ActionChains(self.instance)


### PR DESCRIPTION
Sleeps after scrolling at the interactions level, rather than the driver level. The rationale is that this is something not specific to selenium, but rather an higher level operation.

This was causing a bug when used in Retail because it tried to scroll twice in a row and the scroll there is not atomic (in the sense that the second scroll does not wait for the first and will cause it to misbehave).