### PR TITLE
Use a broader exception handling

### DIFF
--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -209,9 +209,9 @@ class SeleniumDriver(InteractiveDriver):
         :return: The method wrapped on a try-catch for exceptions.
         """
 
-        from selenium.common.exceptions import StaleElementReferenceException
+        from selenium.common.exceptions import WebDriverException
         try: return method(*args, **kwargs)
-        except (StaleElementReferenceException, AssertionError) as exception:
+        except (WebDriverException, AssertionError) as exception:
             self.owner.breadcrumbs.debug("Got exception while waiting: %s" % exception)
             return None
 


### PR DESCRIPTION
Use the base exception class and just let the caller handle null values if needed.