### PR TITLE
Handle TestCase#before exceptions

### DIFF
--- a/src/ripe_rainbow/test_cases.py
+++ b/src/ripe_rainbow/test_cases.py
@@ -57,8 +57,8 @@ class TestCase(appier.Observable):
             self.run_test(test)
 
     def run_test(self, test):
-        self.before()
         try:
+            self.before()
             test()
             self.succeeded(test)
         except errors.SkipError:


### PR DESCRIPTION
TestCase#before is typically used for setting up a test, which might include test-specific logic such as navigating to a certain page and even performing some actions. 

Given this it would make sense to wrap in the error handling logic so that we get things such as screenshots.