### PR TITLE
Add Retail username and password

### DIFF
--- a/src/ripe_rainbow/domain/logic/ripe_retail.py
+++ b/src/ripe_rainbow/domain/logic/ripe_retail.py
@@ -194,13 +194,13 @@ class RipeRetailPart(parts.Part):
 
     @property
     def username(self):
-        username = appier.conf("RETAIL_USERNAME", None)
+        username = appier.conf("RETAIL_USERNAME", "root")
         username = appier.conf("RIPE_RETAIL_USERNAME", username)
         return username
 
     @property
     def password(self):
-        password = appier.conf("RETAIL_PASSWORD", None)
+        password = appier.conf("RETAIL_PASSWORD", "root")
         password = appier.conf("RIPE_RETAIL_PASSWORD", password)
         return password
 

--- a/src/ripe_rainbow/domain/logic/ripe_retail.py
+++ b/src/ripe_rainbow/domain/logic/ripe_retail.py
@@ -193,6 +193,18 @@ class RipeRetailPart(parts.Part):
         return base_url
 
     @property
+    def username(self):
+        username = appier.conf("RETAIL_USERNAME", None)
+        username = appier.conf("RIPE_RETAIL_USERNAME", username)
+        return username
+
+    @property
+    def password(self):
+        password = appier.conf("RETAIL_PASSWORD", None)
+        password = appier.conf("RIPE_RETAIL_PASSWORD", password)
+        return password
+
+    @property
     def base_url(self):
         return self.retail_url
 


### PR DESCRIPTION
Needed for provision to use Retail.

They should probably be called `admin_username` and `admin_password` but in order to do that, their equivalent in `ripe_core` must be changed too.