### PR TITLE
Verification of non existence of element

### DIFF
--- a/src/ripe_rainbow/domain/base/waits.py
+++ b/src/ripe_rainbow/domain/base/waits.py
@@ -49,6 +49,13 @@ class WaitsPart(parts.Part):
             timeout = timeout
         )
 
+    def no_element(self, selector, condition = None, timeout = None):
+        return self.until(
+            lambda d: not self.assertions.exists(selector, condition = condition),
+            message = "Element '%s' found" % selector,
+            timeout = timeout
+        )
+
     def elements(self, selector, condition = None, timeout = None):
         return self.until(
             lambda d: self.assertions.exists_multiple(selector, condition = condition),

--- a/src/ripe_rainbow/domain/logic/ripe_retail.py
+++ b/src/ripe_rainbow/domain/logic/ripe_retail.py
@@ -60,6 +60,16 @@ class RipeRetailPart(parts.Part):
         self.interactions.click_when_possible(".size .button.button-primary.button-apply")
         self.waits.is_not_visible(".size .modal")
 
+    def select_part(self, part):
+        self.interactions.click_when_possible(
+            ".pickers .button-part > p:not(.no-part)",
+            condition = lambda e: e.text == part.upper()
+        )
+
+    def no_material(self, material):
+        self.waits.no_element(".material li[data-material='%s']" % material)
+        self.waits.no_element(".pickers .button-color[data-material='%s']" % material)
+
     def set_part(
         self,
         brand,
@@ -101,10 +111,7 @@ class RipeRetailPart(parts.Part):
         has been done (to verify the final status).
         """
 
-        self.interactions.click_when_possible(
-            ".pickers .button-part > p:not(.no-part)",
-            condition = lambda e: e.text == part.upper()
-        )
+        self.select_part(part)
         self.interactions.click_when_possible(
             ".pickers .button-color[data-material='%s'][data-color='%s']" % (material, color)
         )
@@ -161,10 +168,7 @@ class RipeRetailPart(parts.Part):
         :param color_text: The expected label for the color.
         """
 
-        self.interactions.click_when_possible(
-            ".pickers .button-part",
-            condition = lambda e: e.text == part.upper()
-        )
+        self.select_part(part)
 
         if part_text: self.waits.text(".button-part.active", part_text)
         if color_text: self.waits.text(".button-color.active", color_text)

--- a/src/ripe_rainbow/domain/logic/ripe_retail.py
+++ b/src/ripe_rainbow/domain/logic/ripe_retail.py
@@ -66,9 +66,20 @@ class RipeRetailPart(parts.Part):
             condition = lambda e: e.text == part.upper()
         )
 
-    def no_material(self, material):
+    def no_part(self, part):
+        self.waits.no_element(
+            ".pickers .button-part > p:not(.no-part)",
+            condition = lambda e: e.text == part.upper()
+        )
+
+    def no_material(self, part, material):
+        self.select_part(part)
         self.waits.no_element(".material li[data-material='%s']" % material)
         self.waits.no_element(".pickers .button-color[data-material='%s']" % material)
+
+    def no_color(self, part, color):
+        self.select_part(part)
+        self.waits.no_element(".pickers .button-color[data-color='%s']" % color)
 
     def set_part(
         self,

--- a/src/ripe_rainbow/domain/logic/ripe_white.py
+++ b/src/ripe_rainbow/domain/logic/ripe_white.py
@@ -49,6 +49,34 @@ class RipeWhitePart(parts.Part):
         self.interactions.click_when_possible(".size .button.button-primary.button-apply")
         if wait_closed: self.waits.is_not_visible(".size .modal")
 
+    def select_part(self, part):
+        self.interactions.click_when_possible(
+            ".pickers .button-part > p:not(.no-part)",
+            condition = lambda e: e.is_displayed() and e.text == self._capitalize_words(part)
+        )
+
+    def select_material(self, material):
+        self.interactions.click_when_possible(
+            ".pickers .button-material[data-material='%s']" % material,
+            condition = lambda e: e.is_displayed()
+        )
+
+    def no_part(self, part):
+        self.waits.no_element(
+            ".pickers .button-part > p:not(.no-part)",
+            condition = lambda e: e.is_displayed() and e.text == self._capitalize_words(part)
+        )
+
+    def no_material(self, part, material):
+        self.select_part(part)
+        self.waits.no_element(".pickers .button-material[data-material='%s']" % material)
+        self.waits.no_element(".pickers .button-color[data-material='%s']" % material)
+
+    def no_color(self, part, material, color):
+        self.select_part(part)
+        self.select_material(material)
+        self.waits.no_element(".pickers .button-color[data-color='%s']" % color)
+
     def set_part(
         self,
         brand,
@@ -90,14 +118,8 @@ class RipeWhitePart(parts.Part):
         has been done (to verify the final status).
         """
 
-        self.interactions.click_when_possible(
-            ".pickers .button-part > p:not(.no-part)",
-            condition = lambda e: e.is_displayed() and e.text == self._capitalize_words(part)
-        )
-        self.interactions.click_when_possible(
-            ".pickers .button-material[data-material='%s']" % material,
-            condition = lambda e: e.is_displayed()
-        )
+        self.select_part(part)
+        self.select_material(material)
         self.interactions.click_when_possible(
             ".pickers .button-color[data-material='%s'][data-color='%s']" % (material, color),
             condition = lambda e: e.is_displayed()


### PR DESCRIPTION
Added method that verifies if a element doesn't exist. Also refactor to ripe_retail to create specific methods to click in a specific part of the picker and to check if a material doesn't exist.

Use-case: testing on_part/config/initials manipulation of "choices" (e.g. https://github.com/ripe-tech/ripe-tests/pull/91)