### PR TITLE
Fixes clicking re-try on stale elements

### DIFF
--- a/src/ripe_rainbow/domain/base/interactions.py
+++ b/src/ripe_rainbow/domain/base/interactions.py
@@ -135,11 +135,14 @@ class InteractionsPart(parts.Part):
         :return: The clicked element if there's any otherwise an invalid value.
         """
 
-        element = self.waits.visible(selector, text = text, ensure = False)
-
         # waits until the try click operation is possible meaning that a
         # proper click has been "done" by the driver
         return self.waits.until(
-            lambda d: self.driver.safe(self.driver.click, element),
+            lambda d: self._click(selector, text = text),
             "Element '%s' found but never became clickable" % selector
         )
+
+    def _click(self, selector, text = None):
+        element = self.waits._ensure_element(selector, text = text, ensure = False)
+        if not element: return None
+        self.driver.safe(self.driver.click, element)


### PR DESCRIPTION
There were some situations (opening a modal and clicking on an element) where the reference to the element would get stale between the selection (`element = self.waits.visible(selector, text = text, ensure = False)`) and the click (`self.driver.safe(self.driver.click, element)`).

Because our prior retry strategy would never re-select the element (since the selection was outside the `self.waits.until` of the click), it could never recover from this problem.

This PR changes the strategy to: whenever a click fails, it tries to re-select the element.