### PR TITLE
#188: Fix selector warning retail .size:not(.disabled)

### DIFF
--- a/src/ripe_rainbow/domain/logic/ripe_retail.py
+++ b/src/ripe_rainbow/domain/logic/ripe_retail.py
@@ -35,7 +35,7 @@ class RipeRetailPart(parts.Part):
         :param open: If the size modal window should be opened before selection.
         """
 
-        if open: self.interactions.click(".size:not(.disabled) .button-size")
+        if open: self.interactions.click(".size:not(.disabled) .button-size", text = "SELECT SIZE")
         if gender: self.interactions.click(".size .button-gender", text = gender)
         if scale: self.interactions.click(".size .button-scale", text = str(scale))
 


### PR DESCRIPTION
Fix selector warning Ripe Retail https://github.com/ripe-tech/ripe-tests/issues/188
from: 
if open: self.interactions.click(".size:not(.disabled) .button-size")
to:
if open: self.interactions.click(".size:not(.disabled) .button-size", text = "SELECT SIZE")