### PR TITLE
Fix Retail automatic test select size

### DIFF
--- a/src/ripe_rainbow/domain/logic/ripe_retail.py
+++ b/src/ripe_rainbow/domain/logic/ripe_retail.py
@@ -35,7 +35,7 @@ class RipeRetailPart(parts.Part):
         :param open: If the size modal window should be opened before selection.
         """
 
-        if open: self.interactions.click(".size:not(.disabled) .button-size", text = "SELECT SIZE")
+        if open: self.interactions.click(".size:not(.disabled) > .button-size")
         if gender: self.interactions.click(".size .button-gender", text = gender)
         if scale: self.interactions.click(".size .button-scale", text = str(scale))
 


### PR DESCRIPTION
Fix automatic Retail tests  https://jenkins.platforme.com/job/ripe-tests/1344/console

The PR https://github.com/ripe-tech/ripe-rainbow/pull/96 make this bug because the selector warning was fixed in a wrong way  