### PR TITLE
Add support for emulated mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ rainbow
 | **SEL_MAXIMIZED** | `bool` | `False` | If the [Selenium](https://www.seleniumhq.org) driver should be started in "maximized" (window) mode. |
 | **SEL_HEADLESS** | `bool` | `False` | If the [Selenium](https://www.seleniumhq.org) driver should be started in "headless" (window) mode. |
 | **SEL_WINDOW_SIZE** | `str` | `1920x1080` | Resolution (in pixels) that the [Selenium](https://www.seleniumhq.org) driver will use for the window. |
+| **SEL_MOBILE_DEVICE** | `str` | `Nexus 5` | The mobile device to emulate when running mobile tests. |
 | **SEL_SERVICE_ARGS** | `list` | `[]` | List of command line args to be passed to the driver service that interacts with the browser. |
 | **SEL_POLL_FREQUENCY** | `float` | `None` | The frequency (in seconds) to run the [busy waiting](https://en.wikipedia.org/wiki/Busy_waiting) polling operation on the Selenium `wait` operation. |
 | **RIPE_ID_USERNAME** | `str` | `None` | The username to be used for the RIPE ID authentication. |

--- a/README.md
+++ b/README.md
@@ -18,33 +18,34 @@ rainbow
 
 ## Configuration
 
-| Name                   | Type    | Default     | Description                                                                                                                                          |
-| ---------------------- | ------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **LEVEL**              | `str`   | `INFO`      | Controls the verbosity level of the attached logger.                                                                                                 |
-| **SILENT**             | `bool`  | `False`     | If the test execution should run under silent mode (no stdout from logs).                                                                            |
-| **FILTER**             | `str`   | `None`      | The filter regex to be used by some of the loaders.                                                                                                  |
-| **DRIVER**             | `str`   | `selenium`  | The driver to be used for the interactive mode.                                                                                                      |
-| **TIMEOUT**            | `int`   | `15`        | The timeout in seconds to be used by default for interactions under the interactive testing mode.                                                    |
-| **REPEAT**             | `int`   | `1`         | The number of times to repeat the execution of the tests.                                                                                            |
-| **PROVISION**          | `bool`  | `True`      | If the provision operations should be performed.                                                                                                     |
-| **STACKTRACES**        | `bool`  | `False`     | If "stacktrace" log should be stored on failure of tests.                                                                                            |
-| **STACKTRACES_PATH**   | `bool`  | `.`         | The base path to be used to save the stacktraces log.                                                                                                |
-| **SCREENSHOTS**        | `bool`  | `False`     | If screenshots should be save on failure of tests.                                                                                                   |
-| **SCREENSHOTS_PATH**   | `bool`  | `.`         | The base path to be used to save the screenshots.                                                                                                    |
-| **STORE_LOGS**         | `bool`  | `False`     | If the log files from the multiple logs should be store in case of test failure.                                                                     |
-| **LOGS_PATH**          | `bool`  | `.`         | The base path to be used to save the log files on failure.                                                                                           |
-| **SEL_SECURE**         | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) engine should be executed under a secure approach (should be slower).                                  |
-| **SEL_BROWSER**        | `str`   | `chrome`    | The browser engine that is going to be used by Selenium (eg: `chrome`, `firefox`).                                                                   |
-| **SEL_BROWSER_CACHE**  | `bool`  | `True`      | If the [Selenium](https://www.seleniumhq.org) driver should be with browser cache enabled.                                                           |
-| **SEL_FIX_PATH**       | `bool`  | `True`      | If the [Selenium](https://www.seleniumhq.org) driver should try to fix the environment path.                                                         |
-| **SEL_MAXIMIZED**      | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should be started in "maximized" (window) mode.                                                 |
-| **SEL_HEADLESS**       | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should be started in "headless" (window) mode.                                                  |
-| **SEL_WINDOW_SIZE**    | `str`   | `1920x1080` | Resolution (in pixels) that the [Selenium](https://www.seleniumhq.org) driver will use for the window.                                               |
-| **SEL_PIXEL_RATIO**    | `int`   | `1`         | The pixel ratio that the [Selenium](https://www.seleniumhq.org) driver will use, should be used mostly for device testing.                           |
-| **SEL_SERVICE_ARGS**   | `list`  | `[]`        | List of command line args to be passed to the driver service that interacts with the browser.                                                        |
-| **SEL_POLL_FREQUENCY** | `float` | `None`      | The frequency (in seconds) to run the [busy waiting](https://en.wikipedia.org/wiki/Busy_waiting) polling operation on the Selenium `wait` operation. |
-| **RIPE_ID_USERNAME**   | `str`   | `None`      | The username to be used for the RIPE ID authentication.                                                                                              |
-| **RIPE_ID_PASSWORD**   | `str`   | `None`      | The password to be used for the RIPE ID authentication.                                                                                              |
+| Name                     | Type    | Default     | Description                                                                                                                                          |
+| ------------------------ | ------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **LEVEL**                | `str`   | `INFO`      | Controls the verbosity level of the attached logger.                                                                                                 |
+| **SILENT**               | `bool`  | `False`     | If the test execution should run under silent mode (no stdout from logs).                                                                            |
+| **FILTER**               | `str`   | `None`      | The filter regex to be used by some of the loaders.                                                                                                  |
+| **DRIVER**               | `str`   | `selenium`  | The driver to be used for the interactive mode.                                                                                                      |
+| **TIMEOUT**              | `int`   | `15`        | The timeout in seconds to be used by default for interactions under the interactive testing mode.                                                    |
+| **REPEAT**               | `int`   | `1`         | The number of times to repeat the execution of the tests.                                                                                            |
+| **PROVISION**            | `bool`  | `True`      | If the provision operations should be performed.                                                                                                     |
+| **STACKTRACES**          | `bool`  | `False`     | If "stacktrace" log should be stored on failure of tests.                                                                                            |
+| **STACKTRACES_PATH**     | `bool`  | `.`         | The base path to be used to save the stacktraces log.                                                                                                |
+| **SCREENSHOTS**          | `bool`  | `False`     | If screenshots should be save on failure of tests.                                                                                                   |
+| **SCREENSHOTS_PATH**     | `bool`  | `.`         | The base path to be used to save the screenshots.                                                                                                    |
+| **STORE_LOGS**           | `bool`  | `False`     | If the log files from the multiple logs should be store in case of test failure.                                                                     |
+| **LOGS_PATH**            | `bool`  | `.`         | The base path to be used to save the log files on failure.                                                                                           |
+| **SEL_SECURE**           | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) engine should be executed under a secure approach (should be slower).                                  |
+| **SEL_BROWSER**          | `str`   | `chrome`    | The browser engine that is going to be used by Selenium (eg: `chrome`, `firefox`).                                                                   |
+| **SEL_BROWSER_CACHE**    | `bool`  | `True`      | If the [Selenium](https://www.seleniumhq.org) driver should be with browser cache enabled.                                                           |
+| **SEL_FIX_PATH**         | `bool`  | `True`      | If the [Selenium](https://www.seleniumhq.org) driver should try to fix the environment path.                                                         |
+| **SEL_MAXIMIZED**        | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should be started in "maximized" (window) mode.                                                 |
+| **SEL_HEADLESS**         | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should be started in "headless" (window) mode.                                                  |
+| **SEL_WINDOW_SIZE**      | `str`   | `1920x1080` | Resolution (in pixels) that the [Selenium](https://www.seleniumhq.org) driver will use for the window.                                               |
+| **SEL_MOBILE_EMULATION** | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should use the mobile emulation mode (available for Chrome).                                    |
+| **SEL_PIXEL_RATIO**      | `int`   | `1`         | The pixel ratio that the [Selenium](https://www.seleniumhq.org) driver will use, should be used mostly for device testing.                           |
+| **SEL_SERVICE_ARGS**     | `list`  | `[]`        | List of command line args to be passed to the driver service that interacts with the browser.                                                        |
+| **SEL_POLL_FREQUENCY**   | `float` | `None`      | The frequency (in seconds) to run the [busy waiting](https://en.wikipedia.org/wiki/Busy_waiting) polling operation on the Selenium `wait` operation. |
+| **RIPE_ID_USERNAME**     | `str`   | `None`      | The username to be used for the RIPE ID authentication.                                                                                              |
+| **RIPE_ID_PASSWORD**     | `str`   | `None`      | The password to be used for the RIPE ID authentication.                                                                                              |
 
 | Name                     | Type  | Default                 | Description                                                                                                               |
 | ------------------------ | ----- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ rainbow
 | **SEL_MAXIMIZED** | `bool` | `False` | If the [Selenium](https://www.seleniumhq.org) driver should be started in "maximized" (window) mode. |
 | **SEL_HEADLESS** | `bool` | `False` | If the [Selenium](https://www.seleniumhq.org) driver should be started in "headless" (window) mode. |
 | **SEL_WINDOW_SIZE** | `str` | `1920x1080` | Resolution (in pixels) that the [Selenium](https://www.seleniumhq.org) driver will use for the window. |
-| **SEL_MOBILE_DEVICE** | `str` | `Nexus 5` | The mobile device to emulate when running mobile tests. |
+| **SEL_WINDOW_SIZE_MOBILE** | `str` | `360x640` | Resolution (in pixels) that the [Selenium](https://www.seleniumhq.org) driver will use for the window in tests that require a mobile viewport. |
+| **SEL_PIXEL_RATIO_MOBILE** | `int` | `3` | The pixel ratio to use when running tests tgat require a mobile viewport. |
 | **SEL_SERVICE_ARGS** | `list` | `[]` | List of command line args to be passed to the driver service that interacts with the browser. |
 | **SEL_POLL_FREQUENCY** | `float` | `None` | The frequency (in seconds) to run the [busy waiting](https://en.wikipedia.org/wiki/Busy_waiting) polling operation on the Selenium `wait` operation. |
 | **RIPE_ID_USERNAME** | `str` | `None` | The username to be used for the RIPE ID authentication. |

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ rainbow
 | **SEL_MAXIMIZED**        | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should be started in "maximized" (window) mode.                                                 |
 | **SEL_HEADLESS**         | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should be started in "headless" (window) mode.                                                  |
 | **SEL_WINDOW_SIZE**      | `str`   | `1920x1080` | Resolution (in pixels) that the [Selenium](https://www.seleniumhq.org) driver will use for the window.                                               |
-| **SEL_MOBILE_EMULATION** | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should use the mobile emulation mode (available for Chrome).                                    |
 | **SEL_PIXEL_RATIO**      | `int`   | `1`         | The pixel ratio that the [Selenium](https://www.seleniumhq.org) driver will use, should be used mostly for device testing.                           |
+| **SEL_MOBILE_EMULATION** | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should use the mobile emulation mode (available for Chrome).                                    |
 | **SEL_SERVICE_ARGS**     | `list`  | `[]`        | List of command line args to be passed to the driver service that interacts with the browser.                                                        |
 | **SEL_POLL_FREQUENCY**   | `float` | `None`      | The frequency (in seconds) to run the [busy waiting](https://en.wikipedia.org/wiki/Busy_waiting) polling operation on the Selenium `wait` operation. |
 | **RIPE_ID_USERNAME**     | `str`   | `None`      | The username to be used for the RIPE ID authentication.                                                                                              |

--- a/README.md
+++ b/README.md
@@ -18,57 +18,56 @@ rainbow
 
 ## Configuration
 
-| Name | Type | Default | Description |
-| ----- | ----- | ----- | ----- |
-| **LEVEL** | `str` | `INFO` | Controls the verbosity level of the attached logger. |
-| **SILENT** | `bool` | `False` | If the test execution should run under silent mode (no stdout from logs). |
-| **FILTER** | `str` | `None` | The filter regex to be used by some of the loaders. |
-| **DRIVER** | `str` | `selenium` | The driver to be used for the interactive mode. |
-| **TIMEOUT** | `int` | `15` | The timeout in seconds to be used by default for interactions under the interactive testing mode. |
-| **REPEAT** | `int` | `1` | The number of times to repeat the execution of the tests. |
-| **PROVISION** | `bool` | `True` | If the provision operations should be performed. |
-| **STACKTRACES** | `bool` | `False` | If "stacktrace" log should be stored on failure of tests. |
-| **STACKTRACES_PATH** | `bool` | `.` | The base path to be used to save the stacktraces log. |
-| **SCREENSHOTS** | `bool` | `False` | If screenshots should be save on failure of tests. |
-| **SCREENSHOTS_PATH** | `bool` | `.` | The base path to be used to save the screenshots. |
-| **STORE_LOGS** | `bool` | `False` | If the log files from the multiple logs should be store in case of test failure. |
-| **LOGS_PATH** | `bool` | `.` | The base path to be used to save the log files on failure. |
-| **SEL_SECURE** | `bool` | `False` | If the [Selenium](https://www.seleniumhq.org) engine should be executed under a secure approach (should be slower). |
-| **SEL_BROWSER** | `str` | `chrome` | The browser engine that is going to be used by Selenium (eg: `chrome`, `firefox`). |
-| **SEL_BROWSER_CACHE** | `bool` | `True` | If the [Selenium](https://www.seleniumhq.org) driver should be with browser cache enabled. |
-| **SEL_FIX_PATH** | `bool` | `True` | If the [Selenium](https://www.seleniumhq.org) driver should try to fix the environment path. |
-| **SEL_MAXIMIZED** | `bool` | `False` | If the [Selenium](https://www.seleniumhq.org) driver should be started in "maximized" (window) mode. |
-| **SEL_HEADLESS** | `bool` | `False` | If the [Selenium](https://www.seleniumhq.org) driver should be started in "headless" (window) mode. |
-| **SEL_WINDOW_SIZE** | `str` | `1920x1080` | Resolution (in pixels) that the [Selenium](https://www.seleniumhq.org) driver will use for the window. |
-| **SEL_WINDOW_SIZE_MOBILE** | `str` | `360x640` | Resolution (in pixels) that the [Selenium](https://www.seleniumhq.org) driver will use for the window in tests that require a mobile viewport. |
-| **SEL_PIXEL_RATIO_MOBILE** | `int` | `3` | The pixel ratio to use when running tests tgat require a mobile viewport. |
-| **SEL_SERVICE_ARGS** | `list` | `[]` | List of command line args to be passed to the driver service that interacts with the browser. |
-| **SEL_POLL_FREQUENCY** | `float` | `None` | The frequency (in seconds) to run the [busy waiting](https://en.wikipedia.org/wiki/Busy_waiting) polling operation on the Selenium `wait` operation. |
-| **RIPE_ID_USERNAME** | `str` | `None` | The username to be used for the RIPE ID authentication. |
-| **RIPE_ID_PASSWORD** | `str` | `None` | The password to be used for the RIPE ID authentication. |
+| Name                   | Type    | Default     | Description                                                                                                                                          |
+| ---------------------- | ------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **LEVEL**              | `str`   | `INFO`      | Controls the verbosity level of the attached logger.                                                                                                 |
+| **SILENT**             | `bool`  | `False`     | If the test execution should run under silent mode (no stdout from logs).                                                                            |
+| **FILTER**             | `str`   | `None`      | The filter regex to be used by some of the loaders.                                                                                                  |
+| **DRIVER**             | `str`   | `selenium`  | The driver to be used for the interactive mode.                                                                                                      |
+| **TIMEOUT**            | `int`   | `15`        | The timeout in seconds to be used by default for interactions under the interactive testing mode.                                                    |
+| **REPEAT**             | `int`   | `1`         | The number of times to repeat the execution of the tests.                                                                                            |
+| **PROVISION**          | `bool`  | `True`      | If the provision operations should be performed.                                                                                                     |
+| **STACKTRACES**        | `bool`  | `False`     | If "stacktrace" log should be stored on failure of tests.                                                                                            |
+| **STACKTRACES_PATH**   | `bool`  | `.`         | The base path to be used to save the stacktraces log.                                                                                                |
+| **SCREENSHOTS**        | `bool`  | `False`     | If screenshots should be save on failure of tests.                                                                                                   |
+| **SCREENSHOTS_PATH**   | `bool`  | `.`         | The base path to be used to save the screenshots.                                                                                                    |
+| **STORE_LOGS**         | `bool`  | `False`     | If the log files from the multiple logs should be store in case of test failure.                                                                     |
+| **LOGS_PATH**          | `bool`  | `.`         | The base path to be used to save the log files on failure.                                                                                           |
+| **SEL_SECURE**         | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) engine should be executed under a secure approach (should be slower).                                  |
+| **SEL_BROWSER**        | `str`   | `chrome`    | The browser engine that is going to be used by Selenium (eg: `chrome`, `firefox`).                                                                   |
+| **SEL_BROWSER_CACHE**  | `bool`  | `True`      | If the [Selenium](https://www.seleniumhq.org) driver should be with browser cache enabled.                                                           |
+| **SEL_FIX_PATH**       | `bool`  | `True`      | If the [Selenium](https://www.seleniumhq.org) driver should try to fix the environment path.                                                         |
+| **SEL_MAXIMIZED**      | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should be started in "maximized" (window) mode.                                                 |
+| **SEL_HEADLESS**       | `bool`  | `False`     | If the [Selenium](https://www.seleniumhq.org) driver should be started in "headless" (window) mode.                                                  |
+| **SEL_WINDOW_SIZE**    | `str`   | `1920x1080` | Resolution (in pixels) that the [Selenium](https://www.seleniumhq.org) driver will use for the window.                                               |
+| **SEL_PIXEL_RATIO**    | `int`   | `1`         | The pixel ratio that the [Selenium](https://www.seleniumhq.org) driver will use, should be used mostly for device testing.                           |
+| **SEL_SERVICE_ARGS**   | `list`  | `[]`        | List of command line args to be passed to the driver service that interacts with the browser.                                                        |
+| **SEL_POLL_FREQUENCY** | `float` | `None`      | The frequency (in seconds) to run the [busy waiting](https://en.wikipedia.org/wiki/Busy_waiting) polling operation on the Selenium `wait` operation. |
+| **RIPE_ID_USERNAME**   | `str`   | `None`      | The username to be used for the RIPE ID authentication.                                                                                              |
+| **RIPE_ID_PASSWORD**   | `str`   | `None`      | The password to be used for the RIPE ID authentication.                                                                                              |
 
-| Name | Type | Default |  Description |
-| ----- | ----- | ----- | ----- |
-| **RIPE_SUFFIX** | `str` | `None` | If defined the RIPE product URLs are suffixed with this value (eg: `sbx` implies `https://ripe-pulse-sbx.platforme.com`). |
-| **RIPE_CORE_URL** | `str` | `http://localhost:8080` | The base URL to the RIPE Core instance to be used for tests. |
-| **CORE_URL** | `str` | `http://localhost:8080` | Same as `RIPE_CORE_URL`. |
-| **RIPE_CORE_USERNAME** | `str` | `root` | The username of an admin user to be used to access RIPE Core, it is also used in the provision operation. |
-| **CORE_USERNAME** | `str` | `root` | Same as `RIPE_CORE_USERNAME`. |
-| **RIPE_CORE_PASSWORD** | `str` | `root` | The password of an admin user to be used to access RIPE Core, it is also used in the provision operation. |
-| **CORE_PASSWORD** | `str` | `root` | Same as `RIPE_CORE_PASSWORD`. |
-| **RIPE_RETAIL_URL** | `str` | `http://localhost:8080` | The base URL to the RIPE Retail instance to be used for tests. |
-| **RETAIL_URL** | `str` | `http://localhost:8080` | Same as `RIPE_RETAIL_URL`. |
-| **RIPE_RETAIL_USERNAME** | `str` | `root` | The username of an admin user to be used to access RIPE Retail, it is also used in the provision operation. |
-| **RETAIL_USERNAME** | `str` | `root` | Same as `RIPE_RETAIL_USERNAME`. |
-| **RIPE_RETAIL_PASSWORD** | `str` | `root` | The password of an admin user to be used to access RIPE Retail, it is also used in the provision operation. |
-| **RETAIL_PASSWORD** | `str` | `root` | Same as `RIPE_RETAIL_PASSWORD`. |
-| **RETAIL_URL** | `str` | `http://localhost:8080` | Same as `RIPE_RETAIL_URL`. |
-| **RIPE_PULSE_URL** | `str` | `http://localhost:3000` | The base URL to the RIPE Pulse instance to be used for tests. |
-| **PULSE_URL** | `str` | `http://localhost:3000` | Same as `RIPE_PULSE_URL`. |
-| **RIPE_COPPER_URL** | `str` | `http://localhost:3000` | The base URL to the RIPE Copper instance to be used for tests. |
-| **COPPER_URL** | `str` | `http://localhost:3000` | Same as `RIPE_COPPER_URL`. |
-| **RIPE_WHITE_URL** | `str` | `http://localhost:3000` | The base URL to the RIPE White instance to be used for tests. |
-| **WHITE_URL** | `str` | `http://localhost:3000` | Same as `RIPE_WHITE_URL`. |
+| Name                     | Type  | Default                 | Description                                                                                                               |
+| ------------------------ | ----- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **RIPE_SUFFIX**          | `str` | `None`                  | If defined the RIPE product URLs are suffixed with this value (eg: `sbx` implies `https://ripe-pulse-sbx.platforme.com`). |
+| **RIPE_CORE_URL**        | `str` | `http://localhost:8080` | The base URL to the RIPE Core instance to be used for tests.                                                              |
+| **CORE_URL**             | `str` | `http://localhost:8080` | Same as `RIPE_CORE_URL`.                                                                                                  |
+| **RIPE_CORE_USERNAME**   | `str` | `root`                  | The username of an admin user to be used to access RIPE Core, it is also used in the provision operation.                 |
+| **CORE_USERNAME**        | `str` | `root`                  | Same as `RIPE_CORE_USERNAME`.                                                                                             |
+| **RIPE_CORE_PASSWORD**   | `str` | `root`                  | The password of an admin user to be used to access RIPE Core, it is also used in the provision operation.                 |
+| **CORE_PASSWORD**        | `str` | `root`                  | Same as `RIPE_CORE_PASSWORD`.                                                                                             |
+| **RIPE_RETAIL_URL**      | `str` | `http://localhost:8080` | The base URL to the RIPE Retail instance to be used for tests.                                                            |
+| **RETAIL_URL**           | `str` | `http://localhost:8080` | Same as `RIPE_RETAIL_URL`.                                                                                                |
+| **RIPE_RETAIL_USERNAME** | `str` | `root`                  | The username of an admin user to be used to access RIPE Retail, it is also used in the provision operation.               |
+| **RETAIL_USERNAME**      | `str` | `root`                  | Same as `RIPE_RETAIL_USERNAME`.                                                                                           |
+| **RIPE_RETAIL_PASSWORD** | `str` | `root`                  | The password of an admin user to be used to access RIPE Retail, it is also used in the provision operation.               |
+| **RETAIL_PASSWORD**      | `str` | `root`                  | Same as `RIPE_RETAIL_PASSWORD`.                                                                                           |
+| **RETAIL_URL**           | `str` | `http://localhost:8080` | Same as `RIPE_RETAIL_URL`.                                                                                                |
+| **RIPE_PULSE_URL**       | `str` | `http://localhost:3000` | The base URL to the RIPE Pulse instance to be used for tests.                                                             |
+| **PULSE_URL**            | `str` | `http://localhost:3000` | Same as `RIPE_PULSE_URL`.                                                                                                 |
+| **RIPE_COPPER_URL**      | `str` | `http://localhost:3000` | The base URL to the RIPE Copper instance to be used for tests.                                                            |
+| **COPPER_URL**           | `str` | `http://localhost:3000` | Same as `RIPE_COPPER_URL`.                                                                                                |
+| **RIPE_WHITE_URL**       | `str` | `http://localhost:3000` | The base URL to the RIPE White instance to be used for tests.                                                             |
+| **WHITE_URL**            | `str` | `http://localhost:3000` | Same as `RIPE_WHITE_URL`.                                                                                                 |
 
 ## License
 

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -575,7 +575,10 @@ class SeleniumDriver(InteractiveDriver):
         # crates the base object for the options to be used by
         # the Mozilla Firefox browser
         options = selenium.webdriver.FirefoxOptions()
-        if self.owner.is_mobile: self.owner.skip("Firefox can't run tests that require a mobile device")
+
+        # in case mobile emulation is requested the current test
+        # must be skipped as there's no support available
+        if self.mobile_emulation: self.owner.skip("Firefox can't run tests that require a mobile device")
 
         # in case the headless instance option is set propagates
         # it to the Firefox options object

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -159,6 +159,7 @@ class SeleniumDriver(InteractiveDriver):
         self.maximized = appier.conf("SEL_MAXIMIZED", False, cast = bool)
         self.headless = appier.conf("SEL_HEADLESS", False, cast = bool)
         self.window_size = appier.conf("SEL_WINDOW_SIZE", "1920x1080")
+        self.mobile_device = appier.conf("SEL_MOBILE_DEVICE", "Nexus 5")
         self.poll_frequency = appier.conf("SEL_POLL_FREQUENCY", None, cast = float)
         self.service_args = appier.conf("SEL_SERVICE_ARGS", [], cast = list)
 
@@ -509,6 +510,10 @@ class SeleniumDriver(InteractiveDriver):
         # crates the base object for the options to be used by
         # the Google Chrome browser
         options = selenium.webdriver.ChromeOptions()
+        if self.owner.is_mobile: options.add_experimental_option(
+            "mobileEmulation",
+            dict(deviceName = self.mobile_device)
+        )
 
         # adds some of the default arguments to be used for the
         # execution of the Google Chrome instance
@@ -544,6 +549,7 @@ class SeleniumDriver(InteractiveDriver):
         # crates the base object for the options to be used by
         # the Mozilla Firefox browser
         options = selenium.webdriver.FirefoxOptions()
+        if self.owner.is_mobile: self.owner.skip("Firefox can't run tests that require a mobile device")
 
         # in case the headless instance option is set propagates
         # it to the Firefox options object

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -159,7 +159,8 @@ class SeleniumDriver(InteractiveDriver):
         self.maximized = appier.conf("SEL_MAXIMIZED", False, cast = bool)
         self.headless = appier.conf("SEL_HEADLESS", False, cast = bool)
         self.window_size = appier.conf("SEL_WINDOW_SIZE", "1920x1080")
-        self.mobile_device = appier.conf("SEL_MOBILE_DEVICE", "Nexus 5")
+        self.window_size_mobile = appier.conf("SEL_WINDOW_SIZE_MOBILE", "360x640")
+        self.pixel_ratio_mobile = appier.conf("SEL_PIXEL_RATIO_MOBILE", 3, cast = int)
         self.poll_frequency = appier.conf("SEL_POLL_FREQUENCY", None, cast = float)
         self.service_args = appier.conf("SEL_SERVICE_ARGS", [], cast = list)
 
@@ -510,10 +511,17 @@ class SeleniumDriver(InteractiveDriver):
         # crates the base object for the options to be used by
         # the Google Chrome browser
         options = selenium.webdriver.ChromeOptions()
-        if self.owner.is_mobile: options.add_experimental_option(
-            "mobileEmulation",
-            dict(deviceName = self.mobile_device)
-        )
+        if self.owner.is_mobile:
+            width, height = (int(value) for value in self.window_size_mobile.split("x"))
+            options.add_experimental_option(
+                "mobileEmulation",
+                dict(deviceMetrics = dict(
+                    width = width,
+                    height = height,
+                    pixelRatio = self.pixel_ratio_mobile,
+                    touch = False
+                ))
+            )
 
         # adds some of the default arguments to be used for the
         # execution of the Google Chrome instance

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -28,7 +28,7 @@ LOG_LEVELS_M = dict(
 
 class InteractiveDriver(object):
 
-    def __init__(self, owner):
+    def __init__(self, owner, **kwargs):
         self.owner = owner
 
     @staticmethod
@@ -151,18 +151,28 @@ class InteractiveDriver(object):
 
 class SeleniumDriver(InteractiveDriver):
 
-    def __init__(self, owner):
-        InteractiveDriver.__init__(self, owner)
+    def __init__(self, owner, **kwargs):
+        InteractiveDriver.__init__(self, owner, **kwargs)
         self.secure = appier.conf("SEL_SECURE", False, cast = bool)
         self.browser = appier.conf("SEL_BROWSER", "chrome")
         self.browser_cache = appier.conf("SEL_BROWSER_CACHE", True, cast = bool)
         self.maximized = appier.conf("SEL_MAXIMIZED", False, cast = bool)
         self.headless = appier.conf("SEL_HEADLESS", False, cast = bool)
         self.window_size = appier.conf("SEL_WINDOW_SIZE", "1920x1080")
-        self.window_size_mobile = appier.conf("SEL_WINDOW_SIZE_MOBILE", "360x640")
-        self.pixel_ratio_mobile = appier.conf("SEL_PIXEL_RATIO_MOBILE", 3, cast = int)
+        self.pixel_ratio = appier.conf("SEL_PIXEL_RATIO", 1, cast = int)
+        self.mobile_emulation = appier.conf("SEL_MOBILE_EMULATION", False, cast = bool)
         self.poll_frequency = appier.conf("SEL_POLL_FREQUENCY", None, cast = float)
         self.service_args = appier.conf("SEL_SERVICE_ARGS", [], cast = list)
+        self.secure = kwargs.get("secure", self.secure)
+        self.chrome = kwargs.get("chrome", self.chrome)
+        self.browser_cache = kwargs.get("browser_cache", self.browser_cache)
+        self.maximized = kwargs.get("maximized", self.maximized)
+        self.headless = kwargs.get("headless", self.headless)
+        self.window_size = kwargs.get("window_size", self.window_size)
+        self.pixel_ratio = kwargs.get("pixel_ratio", self.pixel_ratio)
+        self.mobile_emulation = kwargs.get("mobile_emulation", self.mobile_emulation)
+        self.poll_frequency = kwargs.get("poll_frequency", self.poll_frequency)
+        self.service_args = kwargs.get("service_args", self.service_args)
 
     @classmethod
     def label(cls):
@@ -511,14 +521,14 @@ class SeleniumDriver(InteractiveDriver):
         # crates the base object for the options to be used by
         # the Google Chrome browser
         options = selenium.webdriver.ChromeOptions()
-        if self.owner.is_mobile:
-            width, height = (int(value) for value in self.window_size_mobile.split("x"))
+        if self.mobile_emulation:
+            width, height = (int(value) for value in self.window_size.split("x", 1))
             options.add_experimental_option(
                 "mobileEmulation",
                 dict(deviceMetrics = dict(
                     width = width,
                     height = height,
-                    pixelRatio = self.pixel_ratio_mobile,
+                    pixelRatio = self.pixel_ratio,
                     touch = False
                 ))
             )

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -168,8 +168,10 @@ class SeleniumDriver(InteractiveDriver):
         self.browser_cache = kwargs.get("browser_cache", self.browser_cache)
         self.maximized = kwargs.get("maximized", self.maximized)
         self.headless = kwargs.get("headless", self.headless)
+        self.window_size = kwargs.get("resolution", self.window_size)
         self.window_size = kwargs.get("window_size", self.window_size)
         self.pixel_ratio = kwargs.get("pixel_ratio", self.pixel_ratio)
+        self.mobile_emulation = kwargs.get("mobile", self.mobile_emulation)
         self.mobile_emulation = kwargs.get("mobile_emulation", self.mobile_emulation)
         self.poll_frequency = kwargs.get("poll_frequency", self.poll_frequency)
         self.service_args = kwargs.get("service_args", self.service_args)
@@ -521,16 +523,22 @@ class SeleniumDriver(InteractiveDriver):
         # crates the base object for the options to be used by
         # the Google Chrome browser
         options = selenium.webdriver.ChromeOptions()
+
+        # in case the mobile emulation is required then an extra
+        # experimental option is added to allow custom behaviour
+        # (including touch and pixel ratio)
         if self.mobile_emulation:
             width, height = (int(value) for value in self.window_size.split("x", 1))
             options.add_experimental_option(
                 "mobileEmulation",
-                dict(deviceMetrics = dict(
-                    width = width,
-                    height = height,
-                    pixelRatio = self.pixel_ratio,
-                    touch = False
-                ))
+                dict(
+                    deviceMetrics = dict(
+                        width = width,
+                        height = height,
+                        pixelRatio = self.pixel_ratio,
+                        touch = False
+                    )
+                )
             )
 
         # adds some of the default arguments to be used for the

--- a/src/ripe_rainbow/interactive/test_cases.py
+++ b/src/ripe_rainbow/interactive/test_cases.py
@@ -99,3 +99,7 @@ class InteractiveTestCase(test_cases.TestCase):
             log_path = os.path.abspath(log_path)
             log_path = os.path.normpath(log_path)
             memory_handler.flush_to_file(log_path, clear = False)
+
+    @property
+    def is_mobile(self):
+        return False

--- a/src/ripe_rainbow/interactive/test_cases.py
+++ b/src/ripe_rainbow/interactive/test_cases.py
@@ -40,9 +40,14 @@ class InteractiveTestCase(test_cases.TestCase):
     def load_driver(self, start = True):
         driver_s = appier.conf("DRIVER", "selenium")
         driver_s = self.options.get("driver", driver_s)
-        driver = drivers.InteractiveDriver.driver_g(driver_s)(self)
+        driver_c = drivers.InteractiveDriver.driver_g(driver_s)
+        driver = driver_c(self, **self.driver_args)
         if start: driver.start()
         return driver
+
+    @property
+    def driver_args(self):
+        return dict()
 
     def _stacktrace(self, test, ctx = None):
         if not appier.conf("STACKTRACES", False, cast = bool): return
@@ -99,7 +104,3 @@ class InteractiveTestCase(test_cases.TestCase):
             log_path = os.path.abspath(log_path)
             log_path = os.path.normpath(log_path)
             memory_handler.flush_to_file(log_path, clear = False)
-
-    @property
-    def is_mobile(self):
-        return False

--- a/src/ripe_rainbow/test_cases.py
+++ b/src/ripe_rainbow/test_cases.py
@@ -7,7 +7,6 @@ import appier
 
 import logging
 
-from . import util
 from . import errors
 
 class TestCase(appier.Observable):


### PR DESCRIPTION
Not adding it on Firefox because it's not possible to activate the responsive design mode on startup. The alternative would be to use a custom profile, turning on `toolkit.legacyUserProfileCustomizations.stylesheets` and re-defining `#main-window`'s `min-width` in `userChrome.css`.