### PR TITLE
Fallback find for AppiumDriver

### DIFF
--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -1066,17 +1066,27 @@ class AppiumDriver(InteractiveDriver):
 
     def find_element(self, selector):
         if self.in_native:
-            element = self.find_element_by_accessibility_id(selector)
-            if element: return element
-            return self.find_element_by_id(selector)
+            element = None
+            for method in (
+                self.find_element_by_accessibility_id,
+                self.find_element_by_id
+            ):
+                element = method(selector)
+                if element: break
+            return element
         else:
             return self.find_element_by_css_selector(selector)
 
     def find_elements(self, selector):
         if self.in_native:
-            elements = self.find_elements_by_accessibility_id(selector)
-            if len(elements) > 0: return elements
-            return self.find_elements_by_id(selector)
+            elements = []
+            for method in (
+                self.find_elements_by_accessibility_id,
+                self.find_elements_by_id
+            ):
+                elements = method(selector)
+                if len(elements) > 0: break
+            return elements
         else:
             return self.find_elements_by_css_selector(selector)
 

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -1066,13 +1066,17 @@ class AppiumDriver(InteractiveDriver):
 
     def find_element(self, selector):
         if self.in_native:
-            return self.find_element_by_accessibility_id(selector)
+            element = self.find_element_by_accessibility_id(selector)
+            if element: return element
+            return self.find_element_by_id(selector)
         else:
             return self.find_element_by_css_selector(selector)
 
     def find_elements(self, selector):
         if self.in_native:
-            return self.find_elements_by_accessibility_id(selector)
+            elements = self.find_elements_by_accessibility_id(selector)
+            if len(elements) > 0: return elements
+            return self.find_elements_by_id(selector)
         else:
             return self.find_elements_by_css_selector(selector)
 
@@ -1087,6 +1091,12 @@ class AppiumDriver(InteractiveDriver):
 
     def find_elements_by_accessibility_id(self, id):
         return self.instance.find_elements_by_accessibility_id(id)
+
+    def find_element_by_id(self, id):
+        return self.instance.find_element_by_id(id)
+
+    def find_elements_by_id(self, id):
+        return self.instance.find_elements_by_id(id)
 
     def press_key(self, element, key, ensure = True):
         # in case the ensure flag is set makes sure that the element


### PR DESCRIPTION
There are multiple strategies for identifying elements on a mobile application. We've decided to use accessibility IDs to do it since they can easily added on React Native apps. However, some React Native dependencies (e.g. confirmation modals) use a different strategy: IDs rather than accessibility IDs.

In order to be able to maintain a sane API for testers, I propose that we fall back to a different find strategy if the primary one fails. This could eventually be configurable, but I guess it's not worth the effort of propagating the argument upstream.