### PR TITLE
fix: cope with undefined URL

### DIFF
--- a/src/ripe_rainbow/domain/base/logic.py
+++ b/src/ripe_rainbow/domain/base/logic.py
@@ -40,7 +40,9 @@ class LogicPart(parts.Part):
         strict = False
     ):
         # in case the URL is not defined, it only matches if it is
-        # expected to be empty
+        # expected to be empty or not defined, this is a special
+        # situation and early exit is used to avoid the raising of
+        # an exception latter on (would pose issues in workflow)
         if url == None: return expected == None
 
         # runs the normalization process for the provided parameters,

--- a/src/ripe_rainbow/domain/base/logic.py
+++ b/src/ripe_rainbow/domain/base/logic.py
@@ -39,6 +39,10 @@ class LogicPart(parts.Part):
         starts_with = False,
         strict = False
     ):
+        # in case the URL is not defined, it only matches if it is
+        # expected to be empty
+        if url == None: return expected == None
+
         # runs the normalization process for the provided parameters,
         # so that they can be readily compared with the parsed ones
         params = self._normalize_params(params)


### PR DESCRIPTION
Without this, the method would throw `TypeError: can't concat bytes to str` in `url_base = url_p.scheme + "://" + url_p.netloc + url_p.path` which is undesired since our whole retry mechanisms are based on the premise that a condition might not yet be true (a URL that matches X) but it could become so in the future.

This error was exposed in tests where the assertions were able to run before the UI could set the `src` of some images, leading to flaky tests. Example:
- https://jenkins.platforme.com/job/ripe-tests/1999/artifact/stacktraces/personalization_sergio_rossi.PersonalizationSergioRossiTest.both_personalization.log
- https://jenkins.platforme.com/job/ripe-tests/1999/artifact/screenshots/personalization_sergio_rossi.PersonalizationSergioRossiTest.both_personalization.png