### PR TITLE
Util_vue:Adding provision 

### DIFF
--- a/src/ripe_rainbow/domain/wrappers.py
+++ b/src/ripe_rainbow/domain/wrappers.py
@@ -32,6 +32,7 @@ RETAIL_TUPLES = (
 )
 
 UTIL_VUE_TUPLES = (
+    ("provision", logic.ProvisionPart),
     ("id", logic.RipeIdPart),
     ("core", logic.RipeCorePart),
     ("util_vue", logic.RipeUtilVuePart)


### PR DESCRIPTION
Adding provision to util_vue because some utilities use the RIPE-Core data.