### PR TITLE
#130 Update deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Update deprecated methods `find_element_by_*` and `find_elements_by_*` to their respective replacements - [#130](https://github.com/ripe-tech/ripe-rainbow/issues/130)
 
 ## [0.10.1] - 2022-02-01
 

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -8,8 +8,6 @@ import time
 
 import appier
 
-from selenium.webdriver.common.by import By
-
 from .events import EVENT_STRINGIFIERS
 
 from .. import info
@@ -286,9 +284,11 @@ class SeleniumDriver(InteractiveDriver):
         return self.instance.get(url)
 
     def find_element(self, selector):
+        from selenium.webdriver.common.by import By
         return self.instance.find_element(By.CSS_SELECTOR, selector)
 
     def find_elements(self, selector):
+        from selenium.webdriver.common.by import By
         return self.instance.find_elements(By.CSS_SELECTOR, selector)
 
     def find_by_name(self, name):
@@ -1193,9 +1193,11 @@ class AppiumDriver(InteractiveDriver):
             return self.find_elements_by_css_selector(selector)
 
     def find_element_by_css_selector(self, selector):
+        from selenium.webdriver.common.by import By
         return self.instance.find_element(By.CSS_SELECTOR, selector)
 
     def find_elements_by_css_selector(self, selector):
+        from selenium.webdriver.common.by import By
         return self.instance.find_elements(By.CSS_SELECTOR, selector)
 
     def find_element_by_accessibility_id(self, id):
@@ -1205,9 +1207,11 @@ class AppiumDriver(InteractiveDriver):
         return self.instance.find_elements_by_accessibility_id(id)
 
     def find_element_by_id(self, id):
+        from selenium.webdriver.common.by import By
         return self.instance.find_element(By.ID, id)
 
     def find_elements_by_id(self, id):
+        from selenium.webdriver.common.by import By
         return self.instance.find_elements(By.ID, id)
 
     def press_key(self, element, key, ensure=True):

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -285,10 +285,12 @@ class SeleniumDriver(InteractiveDriver):
 
     def find_element(self, selector):
         from selenium.webdriver.common.by import By
+
         return self.instance.find_element(By.CSS_SELECTOR, selector)
 
     def find_elements(self, selector):
         from selenium.webdriver.common.by import By
+
         return self.instance.find_elements(By.CSS_SELECTOR, selector)
 
     def find_by_name(self, name):
@@ -1194,10 +1196,12 @@ class AppiumDriver(InteractiveDriver):
 
     def find_element_by_css_selector(self, selector):
         from selenium.webdriver.common.by import By
+
         return self.instance.find_element(By.CSS_SELECTOR, selector)
 
     def find_elements_by_css_selector(self, selector):
         from selenium.webdriver.common.by import By
+
         return self.instance.find_elements(By.CSS_SELECTOR, selector)
 
     def find_element_by_accessibility_id(self, id):
@@ -1208,10 +1212,12 @@ class AppiumDriver(InteractiveDriver):
 
     def find_element_by_id(self, id):
         from selenium.webdriver.common.by import By
+
         return self.instance.find_element(By.ID, id)
 
     def find_elements_by_id(self, id):
         from selenium.webdriver.common.by import By
+
         return self.instance.find_elements(By.ID, id)
 
     def press_key(self, element, key, ensure=True):

--- a/src/ripe_rainbow/interactive/drivers.py
+++ b/src/ripe_rainbow/interactive/drivers.py
@@ -8,6 +8,8 @@ import time
 
 import appier
 
+from selenium.webdriver.common.by import By
+
 from .events import EVENT_STRINGIFIERS
 
 from .. import info
@@ -284,10 +286,10 @@ class SeleniumDriver(InteractiveDriver):
         return self.instance.get(url)
 
     def find_element(self, selector):
-        return self.instance.find_element_by_css_selector(selector)
+        return self.instance.find_element(By.CSS_SELECTOR, selector)
 
     def find_elements(self, selector):
-        return self.instance.find_elements_by_css_selector(selector)
+        return self.instance.find_elements(By.CSS_SELECTOR, selector)
 
     def find_by_name(self, name):
         return self.instance.find_element_by_name(name)
@@ -1191,10 +1193,10 @@ class AppiumDriver(InteractiveDriver):
             return self.find_elements_by_css_selector(selector)
 
     def find_element_by_css_selector(self, selector):
-        return self.instance.find_element_by_css_selector(selector)
+        return self.instance.find_element(By.CSS_SELECTOR, selector)
 
     def find_elements_by_css_selector(self, selector):
-        return self.instance.find_elements_by_css_selector(selector)
+        return self.instance.find_elements(By.CSS_SELECTOR, selector)
 
     def find_element_by_accessibility_id(self, id):
         return self.instance.find_element_by_accessibility_id(id)
@@ -1203,10 +1205,10 @@ class AppiumDriver(InteractiveDriver):
         return self.instance.find_elements_by_accessibility_id(id)
 
     def find_element_by_id(self, id):
-        return self.instance.find_element_by_id(id)
+        return self.instance.find_element(By.ID, id)
 
     def find_elements_by_id(self, id):
-        return self.instance.find_elements_by_id(id)
+        return self.instance.find_elements(By.ID, id)
 
     def press_key(self, element, key, ensure=True):
         # touches the diag values increment the number of operations


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-rainbow/issues/130 |
| Decisions | - Update deprecated methods `find_element_by_*` and `find_elements_by_*` to their respective replacements |
