### PR TITLE
version: 0.10.2 :rainbow: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+*
+
+## [0.10.2] - 2022-11-03
+
+### Fixed
+
 * Update deprecated methods `find_element_by_*` and `find_elements_by_*` to their respective replacements - [#130](https://github.com/ripe-tech/ripe-rainbow/issues/130)
 
 ## [0.10.1] - 2022-02-01

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 
 setuptools.setup(
     name="ripe-rainbow",
-    version="0.10.1",
+    version="0.10.2",
     author="Platforme International",
     author_email="development@platforme.com",
     description="RIPE Rainbow",

--- a/src/ripe_rainbow/info.py
+++ b/src/ripe_rainbow/info.py
@@ -4,7 +4,7 @@
 import sys
 
 NAME = "RIPE Rainbow"
-VERSION = "0.10.1"
+VERSION = "0.10.2"
 RAINBOW = "🌈"
 LABEL = "%s %s %s" % (NAME, VERSION, RAINBOW)
 PLATFORM = "%s %d.%d.%d.%s %s" % (


### PR DESCRIPTION
### Fixed

* Update deprecated methods `find_element_by_*` and `find_elements_by_*` to their respective replacements - [#130](https://github.com/ripe-tech/ripe-rainbow/issues/130)
