### PR TITLE
fix: remove driver installation step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v1
       - run: python --version
       - run: pip install -r requirements.txt
-      - run: pip install -r drivers.txt
       - run: python setup.py test
       - run: pip install twine wheel
       - run: python setup.py sdist bdist_wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fixed deployment workflow by removing the unnecessary driver installation step
 
 ## [0.10.2] - 2022-11-03
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | - Deployment failed because `pip install selenium` fails for python2.7. https://github.com/ripe-tech/ripe-rainbow/actions/runs/3387298613/jobs/5628980690 |
| Decisions | - Remove the unnecessary driver installation step in the deployment stage. |
