### PR TITLE
feat: remove python 3.5 and python 3.6. Python 3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "rc"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "rc"]
     runs-on: ubuntu-latest
     container: python:${{ matrix.python-version }}
     steps:
@@ -17,9 +17,7 @@ jobs:
           pip install pylint
           curl https://raw.githubusercontent.com/ripe-tech/pylint-config/master/pylintrc --output pylintrc
           PYTHONPATH=src pylint src/ripe_rainbow
-        if: matrix.python-version != '3.5'
       - run: |
           pip install black
           black . --check --config ./pyproject.toml
-        if: matrix.python-version != '3.5'
       - run: python setup.py test


### PR DESCRIPTION
Python 3.5 reached the end of its life on 2021-12-23 https://peps.python.org/pep-0478/ 
Python 3.6 reached the end of its life on 2020-09-30 https://peps.python.org/pep-0494/


